### PR TITLE
Fix menu parent id in component view

### DIFF
--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -56,7 +56,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		// Filter by client id.
 		$clientId = $this->getAttribute('clientid');
 
-		if ($clientId != '')
+		if ($clientId !== '')
 		{
 			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -54,7 +54,9 @@ class JFormFieldMenuParent extends JFormFieldList
 		}
 
 		// Filter by client id.
-		if ($clientId = $this->getAttribute('clientid'))
+		$clientId = $this->getAttribute('clientid');
+
+		if ($clientId != '')
 		{
 			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -56,7 +56,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		// Filter by client id.
 		$clientId = $this->getAttribute('clientid');
 
-		if ($clientId !== '')
+		if ($clientId != '')
 		{
 			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -54,9 +54,9 @@ class JFormFieldMenuParent extends JFormFieldList
 		}
 
 		// Filter by client id.
-		$clientId = $this->getAttribute('clientid');
+		$clientId = $this->getAttribute('clientid', null);
 
-		if ($clientId != '')
+		if (!is_null($clientId))
 		{
 			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -43,6 +43,7 @@ class JFormFieldMenuParent extends JFormFieldList
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
+		// Filter by menu type.
 		if ($menuType = $this->form->getValue('menutype'))
 		{
 			$query->where('a.menutype = ' . $db->quote($menuType));
@@ -50,6 +51,12 @@ class JFormFieldMenuParent extends JFormFieldList
 		else
 		{
 			$query->where('a.menutype != ' . $db->quote(''));
+		}
+
+		// Filter by client id.
+		if ($clientId = $this->getAttribute('clientid'));
+		{
+			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}
 
 		// Prevent parenting to children of this item.

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -54,7 +54,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		}
 
 		// Filter by client id.
-		if ($clientId = $this->getAttribute('clientid'));
+		if ($clientId = $this->getAttribute('clientid'))
 		{
 			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -95,6 +95,7 @@
 			description="COM_MENUS_ITEM_FIELD_PARENT_DESC"
 			default="1"
 			filter="int"
+			clientid="0"
 			size="1">
 			<option
 				value="1">COM_MENUS_ITEM_ROOT</option>


### PR DESCRIPTION
#### Summary of Changes

Access `/administrator/index.php?option=com_menus&view=item&menutype=&layout=edit&tmpl=component`

Before patch Menu parent field shows admin menu items

![image](https://cloud.githubusercontent.com/assets/9630530/17246756/01561318-5586-11e6-9bfa-c9197f7cad7f.png)

After patch does not show.
