### PR TITLE
Avoid ordering error if component does not have ordering

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -251,6 +251,9 @@ class AssociationsHelper extends JHelperContent
 				array_push($cp[$key]->excludeOrdering, 'ordering');
 			}
 
+			// Check the default ordering (ordering is the default, is component does not support, fallback to title).
+			$cp[$key]->defaultOrdering = is_null($cp[$key]->fields->ordering) ? array('title', 'asc') : array('ordering', 'asc');
+
 			// Flag that indicates if the component allow modal layout and so have a custom target button.
 			$cp[$key]->customTarget = (int) file_exists($cp[$key]->adminPath . '/views/' . $cp[$key]->item . 's/tmpl/modal.php');
 		}

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -252,7 +252,7 @@ class AssociationsHelper extends JHelperContent
 			}
 
 			// Check the default ordering (ordering is the default, is component does not support, fallback to title).
-			$cp[$key]->defaultOrdering = is_null($cp[$key]->fields->ordering) ? array('title', 'asc') : array('ordering', 'asc');
+			$cp[$key]->defaultOrdering = is_null($cp[$key]->fields->ordering) ? array('title', 'ASC') : array('ordering', 'ASC');
 
 			// Flag that indicates if the component allow modal layout and so have a custom target button.
 			$cp[$key]->customTarget = (int) file_exists($cp[$key]->adminPath . '/views/' . $cp[$key]->item . 's/tmpl/modal.php');

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -121,7 +121,6 @@ class AssociationsModelAssociations extends JModelList
 		$query->select($db->quoteName('a.id'))
 			->select($db->quoteName('a.' . $component->fields->title, 'title'))
 			->select($db->quoteName('a.' . $component->fields->alias, 'alias'))
-			->select($db->quoteName('a.' . $component->fields->ordering, 'ordering'))
 			->from($db->quoteName($component->dbtable, 'a'));
 
 		// Select author for ACL checks
@@ -156,6 +155,12 @@ class AssociationsModelAssociations extends JModelList
 			)
 			->join('LEFT', $db->quoteName('#__associations', 'asso2') . ' ON ' . $db->quoteName('asso2.key') . ' = ' . $db->quoteName('asso.key'))
 			->group($db->quoteName(array('a.id', 'title', 'language')));
+
+		// If component supports ordering, select the ordering also.
+		if (!is_null($component->fields->ordering))
+		{
+			$query->select($db->quoteName('a.' . $component->fields->ordering, 'ordering'));
+		}
 
 		// If component supports state, select the published state also.
 		if (!is_null($component->fields->published))
@@ -276,7 +281,8 @@ class AssociationsModelAssociations extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$query->order($db->escape($this->getState('list.ordering', 'ordering')) . ' ' . $db->escape($this->getState('list.direction', 'asc')));
+		$query->order($db->escape($this->getState('list.ordering', $this->component->defaultOrdering[0])) . ' '
+			. $db->escape($this->getState('list.direction', $this->component->defaultOrdering[1])));
 
 		return $query;
 	}

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -281,8 +281,7 @@ class AssociationsModelAssociations extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$query->order($db->escape($this->getState('list.ordering', $component->defaultOrdering[0])) . ' '
-			. $db->escape($this->getState('list.direction', $component->defaultOrdering[1])));
+		$query->order($db->escape($this->getState('list.ordering') . ' ' . $this->getState('list.direction')));
 
 		return $query;
 	}

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -281,8 +281,8 @@ class AssociationsModelAssociations extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$query->order($db->escape($this->getState('list.ordering', $this->component->defaultOrdering[0])) . ' '
-			. $db->escape($this->getState('list.direction', $this->component->defaultOrdering[1])));
+		$query->order($db->escape($this->getState('list.ordering', $component->defaultOrdering[0])) . ' '
+			. $db->escape($this->getState('list.direction', $component->defaultOrdering[1])));
 
 		return $query;
 	}

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -123,7 +123,7 @@ class AssociationsViewAssociations extends JViewLegacy
 			{
 				$this->state->set('list.ordering', $this->component->defaultOrdering[0]);
 				$this->state->set('list.direction', strtoupper($this->component->defaultOrdering[1]));
-				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . strtoupper($this->component->defaultOrdering[1]));
+				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0] . ' ' . strtoupper($this->component->defaultOrdering[1]));
 			}
 
 			$this->items      = $this->get('Items');

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -122,9 +122,8 @@ class AssociationsViewAssociations extends JViewLegacy
 			if (in_array($this->state->get('list.ordering', $this->component->defaultOrdering[0]), $this->component->excludeOrdering))
 			{
 				$this->state->set('list.ordering', $this->component->defaultOrdering[0]);
-				$this->state->set('list.direction', $this->component->defaultOrdering[1]);
-				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . $this->component->defaultOrdering[1]);
-			}
+				$this->state->set('list.direction', strtoupper($this->component->defaultOrdering[1]));
+				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . strtoupper($this->component->defaultOrdering[1]));			}
 
 			$this->items      = $this->get('Items');
 			$this->pagination = $this->get('Pagination');

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -122,8 +122,8 @@ class AssociationsViewAssociations extends JViewLegacy
 			if (in_array($this->state->get('list.ordering', $this->component->defaultOrdering[0]), $this->component->excludeOrdering))
 			{
 				$this->state->set('list.ordering', $this->component->defaultOrdering[0]);
-				$this->state->set('list.direction', strtoupper($this->component->defaultOrdering[1]));
-				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0] . ' ' . strtoupper($this->component->defaultOrdering[1]));
+				$this->state->set('list.direction', $this->component->defaultOrdering[1]);
+				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0] . ' ' . $this->component->defaultOrdering[1]);
 			}
 
 			$this->items      = $this->get('Items');

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -123,7 +123,8 @@ class AssociationsViewAssociations extends JViewLegacy
 			{
 				$this->state->set('list.ordering', $this->component->defaultOrdering[0]);
 				$this->state->set('list.direction', strtoupper($this->component->defaultOrdering[1]));
-				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . strtoupper($this->component->defaultOrdering[1]));			}
+				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . strtoupper($this->component->defaultOrdering[1]));
+			}
 
 			$this->items      = $this->get('Items');
 			$this->pagination = $this->get('Pagination');

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -119,11 +119,11 @@ class AssociationsViewAssociations extends JViewLegacy
 			}
 	
 			// Only allow ordering by what the component allows.
-			if (in_array($this->state->get('list.ordering', 'ordering'), $this->component->excludeOrdering))
+			if (in_array($this->state->get('list.ordering', $this->component->defaultOrdering[0]), $this->component->excludeOrdering))
 			{
-				$this->state->set('list.ordering', 'ordering');
-				$this->state->set('list.direction', 'ASC');
-				$this->filterForm->setValue('fullordering', 'list', 'ordering ASC');
+				$this->state->set('list.ordering', $this->component->defaultOrdering[0]);
+				$this->state->set('list.direction', $this->component->defaultOrdering[1]);
+				$this->filterForm->setValue('fullordering', 'list', $this->component->defaultOrdering[0]. ' ' . $this->component->defaultOrdering[1]);
 			}
 
 			$this->items      = $this->get('Items');


### PR DESCRIPTION
For testing we would need a component with associations without ordering/lft column.

So, we can simulate that:

After patch add `$cp[$key]->fields->ordering = null;` in this line https://github.com/joomla-projects/gsoc16_improved-multi-lingual/blob/staging/administrator/components/com_associations/helpers/associations.php#L233

And after do a code review.
