### PR TITLE
Remove hardcoded associations context

### DIFF
--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -152,7 +152,7 @@ class AssociationsModelAssociations extends JModelList
 			->join(
 				'LEFT',
 				$db->quoteName('#__associations', 'asso') . ' ON ' . $db->quoteName('asso.id') . ' = ' . $db->quoteName('a.id')
-				. ' AND ' . $db->quoteName('asso.context') . ' = ' . $db->quote($component->component . '.item')
+				. ' AND ' . $db->quoteName('asso.context') . ' = ' . $db->quote($component->associations->context)
 			)
 			->join('LEFT', $db->quoteName('#__associations', 'asso2') . ' ON ' . $db->quoteName('asso2.key') . ' = ' . $db->quoteName('asso.key'))
 			->group($db->quoteName(array('a.id', 'title', 'language')));


### PR DESCRIPTION
The associations context is somewhat hardcoded, it should use the associations context defined  in the model, not be hardcoded.
We already have it returned by the helper, so let's use it.
#### Tests
- List view associations column work fine
- Code review.
