### PR TITLE
ACL improve

### DIFF
--- a/administrator/components/com_associations/associations.php
+++ b/administrator/components/com_associations/associations.php
@@ -18,13 +18,13 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_associations'))
 JLoader::register('AssociationsHelper', __DIR__ . '/helpers/associations.php');
 
 // Check if user has permission to access the component
-if ($component = JFactory::getApplication()->input->get('component', '', 'string'))
+if ($componentKey = JFactory::getApplication()->input->get('component', '', 'string'))
 {
-	$cp = AssociationsHelper::getComponentProperties($component);
+	$cp = AssociationsHelper::getComponentProperties($componentKey);
 
 	if (!$cp->associations->support)
 	{
-		throw new Exception(JText::_('COM_ASSOCIATIONS_COMPONENT_NOT_SUPPORTED') . " " . $cp->realcomponent, 404);
+		throw new Exception(JText::_('COM_ASSOCIATIONS_COMPONENT_NOT_SUPPORTED') . ' ' . $cp->realcomponent, 404);
 	}
 
 	if (!JFactory::getUser()->authorise('core.manage', $cp->realcomponent))

--- a/administrator/components/com_associations/controllers/association.php
+++ b/administrator/components/com_associations/controllers/association.php
@@ -45,7 +45,7 @@ class AssociationsControllerAssociation extends JControllerForm
 		}
 
 		// Check if reference item can be checked out.
-		if (AssociationsHelper::allowCheckActions($cp, $table) && !$cp->model->checkout($table->id))
+		if (!AssociationsHelper::allowCheckActions($cp, $table) || !$cp->model->checkout($table->id))
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $cp->model->getError()), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_associations&view=associations', false));

--- a/administrator/components/com_associations/controllers/association.php
+++ b/administrator/components/com_associations/controllers/association.php
@@ -45,7 +45,7 @@ class AssociationsControllerAssociation extends JControllerForm
 		}
 
 		// Check if reference item can be checked out.
-		if (!AssociationsHelper::allowCheckActions($cp, $table) || !$cp->model->checkout($table->id))
+		if (is_null($cp->fields->checked_out) || !$cp->model->checkout($table->id))
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $cp->model->getError()), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_associations&view=associations', false));

--- a/administrator/components/com_associations/controllers/association.php
+++ b/administrator/components/com_associations/controllers/association.php
@@ -31,31 +31,26 @@ class AssociationsControllerAssociation extends JControllerForm
 	 */
 	public function edit($key = null, $urlVar = null)
 	{
-		$cp = AssociationsHelper::getComponentProperties($this->input->get('component', '', 'string'));
-
+		$cp   = AssociationsHelper::getComponentProperties($this->input->get('component', '', 'string'));
 		$table = clone $cp->table;
-		$table->load($this->input->get('id', null, 'int'));
+		$table->load($this->input->get('id', 0, 'int'));
 
+		// Check if reference item can be edited.
 		if (!AssociationsHelper::allowEdit($cp, $table))
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_associations&view=associations', false));
+
+			return false;
 		}
 
-		if (!is_null($cp->fields->checked_out))
+		// Check if reference item can be checked out.
+		if (AssociationsHelper::allowCheckActions($cp, $table) && !$cp->model->checkout($table->id))
 		{
-			$id    = $this->input->get('id', 0, 'int');
-			$table = clone $cp->table;
-			$table->load($id);
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $cp->model->getError()), 'error');
+			$this->setRedirect(JRoute::_('index.php?option=com_associations&view=associations', false));
 
-			// Attempt to check-out the record for editing and redirect.
-			if (!in_array($table->{$cp->fields->checked_out}, array(JFactory::getUser()->id, 0)) && !$cp->model->checkout($id))
-			{
-				JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $cp->model->getError()), 'error');
-				$this->setRedirect(JRoute::_('index.php?option=com_associations&view=associations', false));
-
-				return false;
-			}
+			return false;
 		}
 
 		return parent::display();
@@ -73,6 +68,7 @@ class AssociationsControllerAssociation extends JControllerForm
 	public function cancel($key = null)
 	{
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+
 		$cp = AssociationsHelper::getComponentProperties($this->input->get('component', '', 'string'));
 
 		// Only check in, if component allows to check out.

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -364,7 +364,9 @@ class AssociationsHelper extends JHelperContent
 			return false;
 		}
 
+		$user = JFactory::getUser();
+
 		// All other cases. Check if user checked out this item.
-		return in_array($item->{$component->fields->checked_out}, array(JFactory::getUser()->id, 0));
+		return $user->authorise('core.manage', 'com_checkin') || in_array($item->{$component->fields->checked_out}, array($user->id, 0));
 	}
 }

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -288,7 +288,7 @@ class AssociationsHelper extends JHelperContent
 				if (!isset($item->menutypeid))
 				{
 					$table = JTable::getInstance('MenuType');
-					$table->load(array('menutype' => $item->menutype));
+					$table->load(array('menutype' => $item->{$component->fields->menutype}));
 					$item->menutypeid = $table->id;
 				}
 
@@ -297,12 +297,12 @@ class AssociationsHelper extends JHelperContent
 			// For all other components, if item asset does not exist, fallback to category asset (if component supports).
 			elseif (!is_null($component->fields->catid))
 			{
-				$asset->loadByName($component->realcomponent . '.category.' . $item->catid);
+				$asset->loadByName($component->realcomponent . '.category.' . $item->{$component->fields->catid});
 			}
 		}
 
 		// If item asset, category/menu asset does not exist, fallback to component asset.
-		if (is_null($asset->id) && isset($component->fields->catid))
+		if (is_null($asset->id))
 		{
 			$asset->loadByName($component->realcomponent);
 		}

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -201,7 +201,7 @@ class AssociationsHelper extends JHelperContent
 
 			// Get Item type alias, Asset column key and Associations context key.
 			$cp[$key]->typeAlias             = !is_null($cp[$key]->extension) ? 'com_categories.category' : $cp[$key]->model->get('typeAlias');
-			$cp[$key]->assetKey              = $cp[$key]->typeAlias;
+			$cp[$key]->assetKey              = !is_null($cp[$key]->extension) ? $cp[$key]->realcomponent . '.category' : $cp[$key]->typeAlias;
 			$cp[$key]->associations->context = $cp[$key]->model->get('associationsContext');
 
 			// Get the database table.

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -302,8 +302,7 @@ class AssociationsHelper extends JHelperContent
 
 		if (!is_null($component->fields->created_by))
 		{
-			// This check is needed to work in the list and edit view.
-			$canEditOwn = $user->authorise('core.edit.own', $component->assetKey . '.' . $item->id) && (int) $item->{$component->fields->created_by} === (int) $user->id;
+			$canEditOwn = $user->authorise('core.edit.own', $component->assetKey . '.' . $item->id) && $item->{$component->fields->created_by} == $user->id;
 		}
 
 		return $canEditOwn || $user->authorise('core.edit', $component->assetKey . '.' . $item->id);

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -263,21 +263,22 @@ class AssociationsHelper extends JHelperContent
 	}
 
 	/**
-	 * Get the asset key.
+	 * Get a existing asset key using the item parents.
 	 *
 	 * @param   JRegistry  $component  Component properties.
 	 * @param   object     $item       Item db row.
 	 *
-	 * @return  boolean  True on allowed.
+	 * @return  string  The asset key.
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected static function getAssetKey(JRegistry $component, $item = null)
 	{
-		// All other components.
+		// Get the item asset.
 		$asset = JTable::getInstance('Asset');
 		$asset->loadByName($component->assetKey . '.' . $item->id);
 
+		// If the item asset does not exist (ex: com_menus, com_contact, com_newsfeeds).
 		if (is_null($asset->id))
 		{
 			// For menus component, if item asset does not exist, fallback to menu asset.

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -364,9 +364,7 @@ class AssociationsHelper extends JHelperContent
 			return false;
 		}
 
-		$user = JFactory::getUser();
-
 		// All other cases. Check if user checked out this item.
-		return $user->authorise('core.manage', 'com_checkin') || in_array($item->{$component->fields->checked_out}, array($user->id, 0));
+		return in_array($item->{$component->fields->checked_out}, array(JFactory::getUser()->id, 0));
 	}
 }

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -126,14 +126,14 @@ class AssociationsModelAssociations extends JModelList
 		// Select author for ACL checks
 		if (!is_null($component->fields->created_by))
 		{
-			$query->select($db->quoteName('a.' . $component->fields->created_by, 'created_by'));
+			$query->select($db->quoteName('a.' . $component->fields->created_by));
 		}
 
 		// Select checked out data for check in checkins.
 		if (!is_null($component->fields->checked_out) && !is_null($component->fields->checked_out_time))
 		{
-			$query->select($db->quoteName('a.' . $component->fields->checked_out, 'checked_out'))
-				->select($db->quoteName('a.' . $component->fields->checked_out_time, 'checked_out_time'));
+			$query->select($db->quoteName('a.' . $component->fields->checked_out))
+				->select($db->quoteName('a.' . $component->fields->checked_out_time));
 
 			// Join over the users.
 			$query->select($db->quoteName('u.name', 'editor'))

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -199,7 +199,7 @@ class AssociationsModelAssociations extends JModelList
 				->join('LEFT', $db->quoteName('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('a.' . $component->fields->access));
 
 			// Implement View Level Access
-			if (!$user->authorise('core.admin', $component->assetKey))
+			if (!$user->authorise('core.admin', $component->realcomponent))
 			{
 				$query->where('a.' . $component->fields->access . ' IN (' . implode(',', $user->getAuthorisedViewLevels()) . ')');
 			}

--- a/administrator/components/com_associations/models/fields/associatedcomponent.php
+++ b/administrator/components/com_associations/models/fields/associatedcomponent.php
@@ -8,6 +8,8 @@
  */
 defined('JPATH_BASE') or die;
 
+JLoader::register('AssociationsHelper', JPATH_ADMINISTRATOR . '/components/com_associations/helpers/associations.php');
+
 JFormHelper::loadFieldClass('groupedlist');
 
 /**
@@ -36,6 +38,7 @@ class JFormFieldAssociatedComponent extends JFormFieldGroupedList
 	 */
 	protected function getGroups()
 	{
+		$user              = JFactory::getUser();
 		$options           = array();
 		$typeAliasList     = array();
 		$excludeComponents = array(
@@ -63,8 +66,6 @@ class JFormFieldAssociatedComponent extends JFormFieldGroupedList
 			'com_templates',
 			'com_users',
 		);
-
-		$user       = JFactory::getUser();
 
 		// Get all admin components.
 		foreach (glob(JPATH_ADMINISTRATOR . '/components/*', GLOB_NOSORT | GLOB_ONLYDIR) as $componentAdminPath)

--- a/administrator/components/com_associations/views/association/tmpl/edit.php
+++ b/administrator/components/com_associations/views/association/tmpl/edit.php
@@ -62,7 +62,7 @@ $options = array(
 		data-hide-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>"><?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>
 </button>
 
-<form action="<?php echo JRoute::_('index.php?option=com_associations&view=association&layout=' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" data-associatedview="<?php echo $this->component->item; ?>">
+<form action="<?php echo JRoute::_('index.php?option=com_associations&view=association&' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" data-associatedview="<?php echo $this->component->item; ?>">
 
 	<div class="sidebyside">
 

--- a/administrator/components/com_associations/views/association/tmpl/edit.php
+++ b/administrator/components/com_associations/views/association/tmpl/edit.php
@@ -49,50 +49,54 @@ $this->app->getDocument()->addStyleDeclaration('
 	}
 ');
 
-$input      = $this->app->input;
-$layout     = $input->get('layout', '', 'string');
-$component  = $input->get('component', '', 'string');
-$rLanguage  = $input->get('referencelanguage', '', 'string');
+$input   = $this->app->input;
+$options = array(
+			'layout'            => $input->get('layout', '', 'string'),
+			'component'         => $this->component->key,
+			'referencelanguage' => $input->get('referencelanguage', '', 'string'),
+			'id'                => $this->referenceId,
+		);
 ?>
 <button id="toogle-left-panel" class="btn btn-small" 
 		data-show-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_SHOW_REFERENCE'); ?>"
 		data-hide-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>"><?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>
 </button>
 
-<form action="<?php echo JRoute::_(
-			'index.php?option=com_associations&view=association&layout=' . $layout . '
-			&component=' . $component . '&referencelanguage=' . $rLanguage . '&id=' . $this->referenceId
-		); ?>" method="post" name="adminForm" id="adminForm" class="form-validate" data-associatedview="<?php echo $this->component->item; ?>">
+<form action="<?php echo JRoute::_('index.php?option=com_associations&view=association&layout=' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" data-associatedview="<?php echo $this->component->item; ?>">
 
-<div class="sidebyside">
-	<div class="outer-panel" id="left-panel">
-		<div class="inner-panel">
-			<h3><?php echo JText::_('COM_ASSOCIATIONS_REFERENCE_ITEM'); ?></h3>
-			<iframe id="reference-association" name="reference-association"
-				src="<?php echo JRoute::_($this->link); ?>"
-				height="100%" width="400px" scrolling="no"
-				data-id="<?php echo $this->referenceId; ?>"
-				data-language="<?php echo $this->referenceLanguage; ?>">
-			</iframe>
-		</div>
-	</div>
-	<div class="outer-panel" id="right-panel">
-		<div class="inner-panel">
-			<div class="language-selector">
-				<h3><?php echo JText::_('COM_ASSOCIATIONS_ASSOCIATED_ITEM'); ?></h3>
-				<?php echo $this->form->getInput('itemlanguage'); ?>
+	<div class="sidebyside">
+
+		<div class="outer-panel" id="left-panel">
+			<div class="inner-panel">
+				<h3><?php echo JText::_('COM_ASSOCIATIONS_REFERENCE_ITEM'); ?></h3>
+				<iframe id="reference-association" name="reference-association"
+					src="<?php echo JRoute::_($this->editUri . '&id=' . (int) $this->referenceId); ?>"
+					height="100%" width="400px" scrolling="no"
+					data-id="<?php echo $this->referenceId; ?>"
+					data-language="<?php echo $this->referenceLanguage; ?>">
+				</iframe>
 			</div>
-			<iframe id="target-association" name="target-association"
-				src=""
-				height="100%" width="400px" scrolling="no"
-				data-id="0"
-				data-language=""
-				data-editurl="<?php echo JRoute::_($this->targetLink); ?>">
-			</iframe>
 		</div>
+
+		<div class="outer-panel" id="right-panel">
+			<div class="inner-panel">
+				<div class="language-selector">
+					<h3><?php echo JText::_('COM_ASSOCIATIONS_ASSOCIATED_ITEM'); ?></h3>
+					<?php echo $this->form->getInput('itemlanguage'); ?>
+				</div>
+				<iframe id="target-association" name="target-association"
+					src=""
+					height="100%" width="400px" scrolling="no"
+					data-id="0"
+					data-language=""
+					data-editurl="<?php echo JRoute::_($this->editUri . '&id='); ?>">
+				</iframe>
+			</div>
+		</div>
+
 	</div>
-</div>
-<input type="hidden" name="task" value=""/>
-<input type="hidden" name="target-id" id="target-id" value=""/>
-<?php echo JHtml::_('form.token'); ?>
+
+	<input type="hidden" name="task" value=""/>
+	<input type="hidden" name="target-id" id="target-id" value=""/>
+	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -73,10 +73,10 @@ class AssociationsViewAssociation extends JViewLegacy
 		$this->component   = AssociationsHelper::getComponentProperties($input->get('component', '', 'string'));
 
 		// Get reference language.
-		$this->table = clone $this->component->table;
-		$this->table->load($this->referenceId);
+		$table = clone $this->component->table;
+		$table->load($this->referenceId);
 
-		$this->referenceLanguage = $this->table->{$this->component->fields->language};
+		$this->referenceLanguage = $table->{$this->component->fields->language};
 
 		$options = array(
 			'option'    => $this->component->component,
@@ -88,8 +88,7 @@ class AssociationsViewAssociation extends JViewLegacy
 		);
 
 		// Reference and target edit links.
-		$this->link       = 'index.php?' . http_build_query($options) . '&id=' . $this->referenceId;
-		$this->targetLink = 'index.php?' . http_build_query($options) . '&id=';
+		$this->editUri = 'index.php?' . http_build_query($options);
 
 		/*
 		* @todo Review later
@@ -131,19 +130,19 @@ class AssociationsViewAssociation extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$input = JFactory::getApplication()->input;
-		$input->set('hidemainmenu', 1);
-
-		$bar   = JToolbar::getInstance('toolbar');
+		// Hide main menu.
+		JFactory::getApplication()->input->set('hidemainmenu', 1);
 
 		JToolbarHelper::title(JText::_('COM_ASSOCIATIONS_HEADER_EDIT'), 'contract');
+
+		$bar = JToolbar::getInstance('toolbar');
 
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')"'
 			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>'
 			. JText::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button>', 'reference'
 		);
-		
+
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'target\')"'
 			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>' 

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -18,7 +18,7 @@ JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder        = $this->escape($this->state->get('list.ordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));
-$canManageCheckin = $user->authorise('core.manage', 'com_checkin');
+$canManageCheckin = JFactory::getUser()->authorise('core.manage', 'com_checkin');
 $colSpan          =  5;
 $iconStates       = array(
 	-2 => 'icon-trash',

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JLoader::register('AssociationsHelper', JPATH_ADMINISTRATOR . '/components/com_associations/helpers/associations.php');
+
 JHtml::_('jquery.framework');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
@@ -86,7 +88,7 @@ $iconStates = array(
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
 				$canEdit    = AssociationsHelper::allowEdit($this->component, $item);
-				$canCheckin = AssociationsHelper::allowCheckout($this->component, $item);
+				$canCheckin = AssociationsHelper::allowCheckActions($this->component, $item);
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<td class="center">
@@ -101,11 +103,11 @@ $iconStates = array(
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 						<?php endif; ?>
-						<?php if (isset($item->checked_out) && $item->checked_out) : ?>
-							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.', $canCheckin); ?>
+						<?php if (isset($item->{$component->fields->checked_out}) && $item->{$component->fields->checked_out}) : ?>
+							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->{$component->fields->checked_out_time}, 'associations.', $canCheckin); ?>
 						<?php endif; ?>
 						<?php if ($canEdit) : ?>
-							<a href="<?php echo JRoute::_($this->editLink . '&id=' . (int) $item->id); ?>">
+							<a href="<?php echo JRoute::_($this->editUri . '&id=' . (int) $item->id); ?>">
 							<?php echo $this->escape($item->title); ?></a>
 						<?php else : ?>
 							<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -16,10 +16,11 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$listOrder  = $this->escape($this->state->get('list.ordering'));
-$listDirn   = $this->escape($this->state->get('list.direction'));
-$colSpan    =  5;
-$iconStates = array(
+$listOrder        = $this->escape($this->state->get('list.ordering'));
+$listDirn         = $this->escape($this->state->get('list.direction'));
+$canManageCheckin = $user->authorise('core.manage', 'com_checkin');
+$colSpan          =  5;
+$iconStates       = array(
 	-2 => 'icon-trash',
 	0  => 'icon-unpublish',
 	1  => 'icon-publish',
@@ -88,7 +89,7 @@ $iconStates = array(
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
 				$canEdit    = AssociationsHelper::allowEdit($this->component, $item);
-				$canCheckin = AssociationsHelper::allowCheckActions($this->component, $item);
+				$canCheckin = $canManageCheckin || AssociationsHelper::allowCheckActions($this->component, $item);
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<td class="center">

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -103,8 +103,8 @@ $iconStates = array(
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 						<?php endif; ?>
-						<?php if (isset($item->{$component->fields->checked_out}) && $item->{$component->fields->checked_out}) : ?>
-							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->{$component->fields->checked_out_time}, 'associations.', $canCheckin); ?>
+						<?php if (isset($item->{$this->component->fields->checked_out}) && $item->{$this->component->fields->checked_out}) : ?>
+							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->{$this->component->fields->checked_out_time}, 'associations.', $canCheckin); ?>
 						<?php endif; ?>
 						<?php if ($canEdit) : ?>
 							<a href="<?php echo JRoute::_($this->editUri . '&id=' . (int) $item->id); ?>">

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -174,7 +174,7 @@ class AssociationsViewAssociations extends JViewLegacy
 		*/
 		// JToolbarHelper::editList('association.edit');
 
-		if (isset($this->component) && $user->authorise('core.admin', $this->component->component))
+		if (isset($this->component) && $user->authorise('core.admin', $this->component->realcomponent))
 		{
 			JToolbarHelper::checkin('associations.checkin', 'JTOOLBAR_CHECKIN', true);
 		}

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -137,7 +137,7 @@ class AssociationsViewAssociations extends JViewLegacy
 				'task'       => 'association.edit',
 			);
 
-			$this->editLink = 'index.php?option=com_associations&view=association&' . http_build_query($linkParameters);
+			$this->editUri = 'index.php?option=com_associations&view=association&' . http_build_query($linkParameters);
 
 			// Load the current component html helper class.
 			JLoader::register($this->component->associations->htmlhelper->class, $this->component->associations->htmlhelper->file);

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -174,7 +174,7 @@ class AssociationsViewAssociations extends JViewLegacy
 		*/
 		// JToolbarHelper::editList('association.edit');
 
-		if (isset($this->component) && $user->authorise('core.admin', $this->component->realcomponent))
+		if (isset($this->component) && !is_null($this->component->fields->checked_out))
 		{
 			JToolbarHelper::checkin('associations.checkin', 'JTOOLBAR_CHECKIN', true);
 		}


### PR DESCRIPTION
Problems i notice: See https://github.com/joomla/joomla-cms/issues/11466
#### com_contact contacts
- Setting the contact component `core.edit` to `No` and `core.edit.own` to `Yes` should allow the user to edit the items he created inside any category, but core does not allows.
- Setting a contact category `core.edit` to `No` and `core.edit.own` to `Yes` should allow the user to edit the items he created inside that category, but core does not allows.
#### com_newsfeeds newsfeeds
- Setting the newsfeeds component `core.edit` to `No` and `core.edit.own` to `Yes` should allow the user to edit the items he created inside any category, but core does not allows.
- Setting a newsfeed category `core.edit` to `No` and `core.edit.own` to `Yes` should allow the user to edit the items he created inside that category, but core does not allows.

com_associations allows it. So it's a bug that needs to be solved in the core.

The rest seems to be working.
Please test.
