### PR TITLE
Flexible db fields (PoC)

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -228,9 +228,6 @@ class AssociationsHelper extends JHelperContent
 			$cp[$key]->dbtable = $cp[$key]->table->get('_tbl');
 
 			// Get the table fields.
-			$cp[$key]->tableFields = $cp[$key]->table->getFields();
-
-			// Get the table fields.
 			$cp[$key]->tableFields = $cp[$key]->table->get('fieldsMapping');
 
 			// Component fields

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -230,25 +230,24 @@ class AssociationsHelper extends JHelperContent
 			// Get the table fields.
 			$cp[$key]->tableFields = $cp[$key]->table->getFields();
 
+			// Get the table fields.
+			$cp[$key]->tableFields = $cp[$key]->table->get('fieldsMapping');
+
 			// Component fields
-			// @todo This need should be checked hardcoding.
 			$cp[$key]->fields                   = new Registry;
-			$cp[$key]->fields->title            = isset($cp[$key]->tableFields['name']) ? 'name' : null;
-			$cp[$key]->fields->title            = isset($cp[$key]->tableFields['title']) ? 'title' : $cp[$key]->fields->title;
-			$cp[$key]->fields->alias            = isset($cp[$key]->tableFields['alias']) ? 'alias' : null;
-			$cp[$key]->fields->ordering         = isset($cp[$key]->tableFields['ordering']) ? 'ordering' : null;
-			$cp[$key]->fields->ordering         = isset($cp[$key]->tableFields['lft']) ? 'lft' : $cp[$key]->fields->ordering;
-			$cp[$key]->fields->menutype         = isset($cp[$key]->tableFields['menutype']) ? 'menutype' : null;
-			$cp[$key]->fields->level            = isset($cp[$key]->tableFields['level']) ? 'level' : null;
-			$cp[$key]->fields->catid            = isset($cp[$key]->tableFields['catid']) ? 'catid' : null;
-			$cp[$key]->fields->language         = isset($cp[$key]->tableFields['language']) ? 'language' : null;
-			$cp[$key]->fields->access           = isset($cp[$key]->tableFields['access']) ? 'access' : null;
-			$cp[$key]->fields->published        = isset($cp[$key]->tableFields['state']) ? 'state' : null;
-			$cp[$key]->fields->published        = isset($cp[$key]->tableFields['published']) ? 'published' : $cp[$key]->fields->published;
-			$cp[$key]->fields->created_by       = isset($cp[$key]->tableFields['created_user_id']) ? 'created_user_id' : null;
-			$cp[$key]->fields->created_by       = isset($cp[$key]->tableFields['created_by']) ? 'created_by' : $cp[$key]->fields->created_by;
-			$cp[$key]->fields->checked_out      = isset($cp[$key]->tableFields['checked_out']) ? 'checked_out' : null;
-			$cp[$key]->fields->checked_out_time = isset($cp[$key]->tableFields['checked_out_time']) ? 'checked_out_time' : null;
+			$cp[$key]->fields->id               = isset($cp[$key]->tableFields['id']) ? $cp[$key]->tableFields['id'] : null;
+			$cp[$key]->fields->title            = isset($cp[$key]->tableFields['title']) ? $cp[$key]->tableFields['title'] : null;
+			$cp[$key]->fields->alias            = isset($cp[$key]->tableFields['alias']) ? $cp[$key]->tableFields['alias'] : null;
+			$cp[$key]->fields->ordering         = isset($cp[$key]->tableFields['ordering']) ? $cp[$key]->tableFields['ordering'] : null;
+			$cp[$key]->fields->menutype         = isset($cp[$key]->tableFields['menutype']) ? $cp[$key]->tableFields['menutype'] : null;
+			$cp[$key]->fields->level            = isset($cp[$key]->tableFields['level']) ? $cp[$key]->tableFields['level'] : null;
+			$cp[$key]->fields->catid            = isset($cp[$key]->tableFields['catid']) ? $cp[$key]->tableFields['catid'] : null;
+			$cp[$key]->fields->language         = isset($cp[$key]->tableFields['language']) ? $cp[$key]->tableFields['language'] : null;
+			$cp[$key]->fields->access           = isset($cp[$key]->tableFields['access']) ? $cp[$key]->tableFields['access'] : null;
+			$cp[$key]->fields->published        = isset($cp[$key]->tableFields['published']) ? $cp[$key]->tableFields['published'] : null;
+			$cp[$key]->fields->created_by       = isset($cp[$key]->tableFields['created_by']) ? $cp[$key]->tableFields['created_by'] : null;
+			$cp[$key]->fields->checked_out      = isset($cp[$key]->tableFields['checked_out']) ? $cp[$key]->tableFields['checked_out'] : null;
+			$cp[$key]->fields->checked_out_time = isset($cp[$key]->tableFields['checked_out_time']) ? $cp[$key]->tableFields['checked_out_time'] : null;
 
 			// Disallow ordering according to component.
 			$cp[$key]->excludeOrdering = array();

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -57,7 +57,7 @@ class ContactTableContact extends JTable
 	 */
 	public function __construct(&$db)
 	{
-		parent::__construct('#__contact_details', 'id', $db);
+		parent::__construct('#__contact_details', $this->fieldsMapping['id'], $db);
 
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_contact.contact'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_contact.contact'));

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -19,6 +19,28 @@ use Joomla\Registry\Registry;
 class ContactTableContact extends JTable
 {
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'name',
+		'alias'            => 'alias',
+		'published'        => 'state',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => 'catid',
+		'menutype'         => null,
+		'ordering'         => 'ordering',
+		'level'            => null,
+		'created_by'       => 'created_by',
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * Ensure the params and metadata in json encoded in the bind method
 	 *
 	 * @var    array

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -17,6 +17,28 @@ defined('_JEXEC') or die;
 class NewsfeedsTableNewsfeed extends JTable
 {
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'name',
+		'alias'            => 'alias',
+		'published'        => 'published',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => 'catid',
+		'menutype'         => null,
+		'ordering'         => 'ordering',
+		'level'            => null,
+		'created_by'       => 'created_by',
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * Ensure the params, metadata and images are json encoded in the bind method
 	 *
 	 * @var    array

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -53,7 +53,7 @@ class NewsfeedsTableNewsfeed extends JTable
 	 */
 	public function __construct(&$db)
 	{
-		parent::__construct('#__newsfeeds', 'id', $db);
+		parent::__construct('#__newsfeeds', $this->fieldsMapping['id'], $db);
 
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -54,6 +54,28 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	protected $_tbl_keys = array();
 
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'title',
+		'alias'            => 'alias',
+		'published'        => 'published',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => 'catid',
+		'menutype'         => null,
+		'ordering'         => 'ordering',
+		'level'            => null,
+		'created_by'       => 'created_by',
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * JDatabaseDriver object.
 	 *
 	 * @var    JDatabaseDriver

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -19,6 +19,28 @@ use Joomla\Registry\Registry;
 class JTableCategory extends JTableNested
 {
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'title',
+		'alias'            => 'alias',
+		'published'        => 'published',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => null,
+		'menutype'         => null,
+		'ordering'         => 'lft',
+		'level'            => 'level',
+		'created_by'       => 'created_user_id',
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.
@@ -27,7 +49,7 @@ class JTableCategory extends JTableNested
 	 */
 	public function __construct(JDatabaseDriver $db)
 	{
-		parent::__construct('#__categories', 'id', $db);
+		parent::__construct('#__categories', $this->fieldsMapping['id'], $db);
 
 		JTableObserverTags::createObserver($this, array('typeAlias' => '{extension}.category'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => '{extension}.category'));

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -20,6 +20,28 @@ use Joomla\Registry\Registry;
 class JTableContent extends JTable
 {
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'title',
+		'alias'            => 'alias',
+		'published'        => 'state',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => 'catid',
+		'menutype'         => null,
+		'ordering'         => 'ordering',
+		'level'            => null,
+		'created_by'       => 'created_by',
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object
@@ -28,7 +50,7 @@ class JTableContent extends JTable
 	 */
 	public function __construct(JDatabaseDriver $db)
 	{
-		parent::__construct('#__content', 'id', $db);
+		parent::__construct('#__content', $this->fieldsMapping['id'], $db);
 
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_content.article'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_content.article'));

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -49,7 +49,7 @@ class JTableMenu extends JTableNested
 	 */
 	public function __construct(JDatabaseDriver $db)
 	{
-		parent::__construct('#__menu', 'id', $db);
+		parent::__construct('#__menu', $this->fieldsMapping['id'], $db);
 
 		// Set the default access level.
 		$this->access = (int) JFactory::getConfig()->get('access');

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -19,6 +19,28 @@ use Joomla\Registry\Registry;
 class JTableMenu extends JTableNested
 {
 	/**
+	 * Mapping of most used fields in the table.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fieldsMapping = array(
+		'id'               => 'id',
+		'title'            => 'title',
+		'alias'            => 'alias',
+		'published'        => 'published',
+		'access'           => 'access',
+		'language'         => 'language',
+		'catid'            => null,
+		'menutype'         => 'menutype',
+		'ordering'         => 'lft',
+		'level'            => 'level',
+		'created_by'       => null,
+		'checked_out'      => 'checked_out',
+		'checked_out_time' => 'checked_out_time',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.


### PR DESCRIPTION
Flexible db fields.

Imporoves:
- Avoids one db query for component to get the table fields.
- Component can use the db fields they want.
#### Test

All items in com_association list views work as before.
#### 3º Party Support

If 3º party use the same fields as JTable doesn't to do anything.
If 3º party does not use the same fields as JTable, needs to add mapping property to his JTable overrides.
