### PR TITLE
Forcedlanguage lost after using Clear FIX

### DIFF
--- a/media/com_associations/js/sidebyside.js
+++ b/media/com_associations/js/sidebyside.js
@@ -74,7 +74,7 @@ jQuery(document).ready(function($) {
 			
 			// Reset switcher after removing association
 			var currentSwitcher = $('#jform_itemlanguage').val();
-			var currentLang = referenceLang.replace(/_/,'-');
+			var currentLang = targetLang.replace(/_/,'-');
 			$('#jform_itemlanguage option[value=\"' + currentSwitcher + '\"]').val(currentLang + ':0:add');
 			$('#jform_itemlanguage').val('').change();
 			$('#jform_itemlanguage').trigger('liszt:updated');


### PR DESCRIPTION
Pull Request for Issue #107
### Summary of Changes

When I was clearing association, I was giving the switcher reference language instead of target (for that position), i.e. if fr-FR had fr-FR:92:edit, when clearing it would replace with en-GB:0:add, everything was right except language.
### Testing Instructions

Clear an association and check if forced language on the target is still set to reference's forced language
